### PR TITLE
Working VTL for lambdaless universal application/x-www-form-urlencoded to JSON mapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# IDE
+.idea/

--- a/cf-api.yaml
+++ b/cf-api.yaml
@@ -68,81 +68,34 @@ Resources:
               - 'arn:aws:apigateway:${AWS::Region}:sqs:path/${AWS::AccountId}/${QueueName}'
               - QueueName: !GetAtt SqsQueue.QueueName
         RequestTemplates:
-          #### 
-          # First of all this type 'application/json' is for JSON payloads and is not a case here
-          # it's here only because most of the people tried this and it works 
-          # which doesn't really help at all.
-          #
-          # application/json: |
-          #   Action=SendMessage&MessageBody=$input.body
-
-
           ####
           # CONFIGURATION 1
+          #   After URL encoding this works 100% - without any caveats, nothing is lost here.
           #
-          # This kinda works but:
-          # 1) doesn't include full payload in the SQS messages
-          # 2) doesn't convert  www-urlencoded data into JSON.
-          #
-          # Basically it's here just to prove that IAM role is correct!
-          #
-          application/x-www-form-urlencoded: |
-            Action=SendMessage&MessageBody=$input.body
+          # application/x-www-form-urlencoded: |
+          #  #set( $fullBody = $util.urlEncode($input.body) )
+          #  Action=SendMessage&MessageBody=$fullBody
 
           ####
           # CONFIGURATION 2
-          #
-          # This is a VTL script, which causes the problem
+          #   Static JSON provided as body - works 100%.
           #
           # application/x-www-form-urlencoded: |
-          #   ## Parses x-www-urlencoded data to JSON for AWS' API Gateway
-          #   ##
-          #   ## Author: Christian E Willman <christian@willman.io>
-
-          #   #if ( $context.httpMethod == "POST" )
-          #     #set( $requestBody = $input.path('$') )
-          #   #else
-          #     #set( $requestBody = "" )
-          #   #end
-
-          #   #set( $keyValuePairs = $requestBody.split("&") )
-          #   #set( $params = [] )
-
-          #   ## Filter empty key-value pairs
-          #   #foreach( $kvp in $keyValuePairs )
-          #     #set( $operands = $kvp.split("=") )
-
-          #     #if( $operands.size() == 1 || $operands.size() == 2 )
-          #       #set( $success = $params.add($operands) )
-          #     #end
-          #   #end
-
-          #   Action=SendMessage&MessageBody=
-          #   {
-          #     #foreach( $param in $params )
-          #       #set( $key = $util.urlDecode($param[0]) )
-
-          #       #if( $param.size() > 1 )
-          #         #set( $value = $util.urlDecode($param[1]) )
-          #       #else
-          #         #set( $value = "" )
-          #       #end
-
-          #       "$key": "$value"#if( $foreach.hasNext ),#end
-          #     #end
-          #   }
+          #  Action=SendMessage&MessageBody={
+          #     "type": "test",
+          #     "foo": "barbarbar"
+          #  }
 
           ####
           # CONFIGURATION 3
+          #   Fixed VTL script, works in all cases.
+          #   YOU CANNOT HAVE ANY WHITESPACES AND PAYLOAD MUST BE URLENCODED.
           #
-          # 
-          #
-          # application/x-www-form-urlencoded: |
-          #   Action=SendMessage&MessageBody={
-          #       "type": "test",
-          #       "foo": "bar"
-          #   }
-          
+          application/x-www-form-urlencoded: |
+            #if($context.httpMethod=="POST")#set($requestBody=$input.path('$'))#else#set($requestBody="")#end#set($keyValuePairs=$requestBody.split("&"))#set($params=[])#foreach($kvp in $keyValuePairs)#set($operands=$kvp.split("="))#if($operands.size()==1||$operands.size()==2)#set($success=$params.add($operands))#end#end
+            #set($rawJSON="{#foreach($param in $params)#set($key=$util.urlDecode($param[0]))#if($param.size()>1)#set($value=$util.urlDecode($param[1]))#else#set($value="""")#end""$key"":""$value""#if($foreach.hasNext),#end#end}")
+            #set($fullBodyAsQueryParameter=$util.urlEncode($rawJSON))
+            Action=SendMessage&MessageBody=$fullBodyAsQueryParameter
 
         PassthroughBehavior: NEVER
         IntegrationResponses:


### PR DESCRIPTION
So ... there are 3 lessons learnt here:

1. Everything works "_as designed_".
2. Documentation for API Gateway and VTL used there sucks.
3. VTL sucks as language, and it may output unnecessary whitespaces - which can break everything.

*TL;DR*: If you are dynamically construct payload for MessageBody in VTL, you need to provide the whole invocation `Action=SendMessage&MessageBody=...` **without any whitespaces**, with double `"` inside JSON (if you use `#set( $val = "...")` with double quotes), and `MessageBody` value **must** be URL encoded.

Why documentation sucks? Because it requires hidden knowledge about how VTL outputs stuff (and may output unnecessary whitespaces), also direct integration documentation does not state that any additional whitespaces in the provided _query string command_ will break integration.

By accident I found those 2 things:

1. [`SendMessage` SQS API Documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html) which says (_in between the lines_) that `MessageBody` should be URL encoded as we pass that as **request parameter**.
2. This [answer on StackOverflow](https://stackoverflow.com/a/48339653/2511727) that shows right syntax for multiline strings and `#set` directive, plus [this comment](https://stackoverflow.com/questions/48339652/how-to-set-object-key-values-in-aws-api-gateway-mapping-template#comment83668320_48339653) about unnecessary whitespaces.

Trial and error with those 2 concepts provided a working solution. Here is the original:

https://github.com/willmanio/aws-api-gateway-bodyparser/blob/master/aws-api-gateway-bodyparser.vtl

... but I had to remove comments referring to the author (_sorry!_) of that VTL template as a sanity check, but essentially my only addition is as follows:

```
## Parses x-www-urlencoded data to JSON for AWS' API Gateway
##
## Author: Christian E Willman <christian@willman.io>
#if ( $context.httpMethod == "POST" )
  #set( $requestBody = $input.path('$') )
#else
  #set( $requestBody = "" )
#end
#set( $keyValuePairs = $requestBody.split("&") )
#set( $params = [] )
## Filter empty key-value pairs
#foreach( $kvp in $keyValuePairs )
  #set( $operands = $kvp.split("=") )
  #if( $operands.size() == 1 || $operands.size() == 2 )
    #set( $success = $params.add($operands) )
  #end
#end
#set( $rawJSON = "{
  #foreach( $param in $params )
    #set( $key = $util.urlDecode($param[0]) )
    #if( $param.size() > 1 )
      #set( $value = $util.urlDecode($param[1]) )
    #else
      #set( $value = """" )
    #end
    ""$key"": ""$value""#if( $foreach.hasNext ),#end
  #end
}" )
#set( $fullBodyAsQueryParameter = $util.urlEncode($rawJSON) )
Action=SendMessage&MessageBody=$fullBodyAsQueryParameter
```

Pay attention to:

1. Added `"` for a multiline `#set`.
2. Double `"` inside the same multiline `#set`.
3. `$util.urlEncode` at the end (_yes, it has to be done on variable_).
4. Removed empty lines in VTL, as it creates unnecessary line breaks - also, you need to remove additional whitespaces from the logic to not create anything in between - but that would make the whole example _illegible_.